### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
     <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
-    <central-publishing-maven-plugin.version>0.6.0</central-publishing-maven-plugin.version>
+    <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
     <junit.version>5.11.4</junit.version>
     <junit-pioneer.version>2.3.0</junit-pioneer.version>
     <jacoco-plugin.version>0.8.13</jacoco-plugin.version>


### PR DESCRIPTION
Bump Maven Central publisher plugin to version 0.8.0 to fix bug where job fails despite a successful publish